### PR TITLE
Use Core Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,3 @@ _build/
 # oasis generated files
 setup.data
 setup.log
-
-# Merlin configuring file for Vim and Emacs
-.merlin

--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,3 @@
+S .
+B _build
+PKG Core

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is based on the original implementation of Troll in Standard ML (Mo
 
 ## Building the project
 
-The project can be compiled using standard OCaml tools (`ocamlc`, `ocamllex`, `ocamlyacc`) available in the official OCaml distributions.
+In addition to the standard OCaml tools (`ocamlc`, `ocamllex`, `ocamlyacc`) available in the official OCaml distributionst he project uses `Core` library and `corebuild` for compiling.
 
 Run the command `./build.sh` to generate the binary.
 

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,3 @@
-ocamlyacc parser.mly
-ocamllex lexer.mll
-ocamlc -o troll \
- syntax.ml\
- parser.mli parser.ml \
- lexer.ml \
- interpreter.mli interpreter.ml \
- main.ml
+#!/bin/bash 
+corebuild main.native
+mv main.native troll

--- a/main.ml
+++ b/main.ml
@@ -204,11 +204,8 @@ struct
                    defs d,(0,0))))
       | Some n -> run0 args filename n defs
 
-  let _ =
-    Random.self_init();
-    let argv = Array.to_list Sys.argv in
-    try
-      run0 (List.tl argv) "" 1 (fun d -> d)
+  let main filename = try
+      run0 [] filename 1 (fun d -> d)
     with Parsing.YYexit ob -> errorMess "Parser-exit\n"
        | Parsing.Parse_error ->
          let (p1,p2) = (0, 0) in
@@ -226,5 +223,21 @@ struct
                     ^ string_of_int lin ^ ", column " ^ string_of_int col)
        | Sys_error s -> errorMess ("Exception: " ^ s)
        | ParamErr s -> errorMess ("Bad command-line parameter: " ^ s)
+
+  let spec =
+    let open Core.Command.Spec in
+    empty
+    +> anon ("filename" %: string)
+
+  let command =
+    Core.Command.basic
+      ~summary:"Simulate dice rolling based on a domain-specific syntax"
+      ~readme:(fun () -> "Command-line options")
+      spec
+      (fun filename () -> main filename)
+
+  let _ =
+    Random.self_init();
+    Core.Command.run ~version:"0.0.1" command
 end
 

--- a/main.ml
+++ b/main.ml
@@ -160,8 +160,9 @@ struct
 
   let run filename n defs =
     let lb = createLexerStream
-        (if filename = "" then stdin
-         else open_in filename) in
+        (match filename with
+           Some (filename) -> (open_in filename)
+         | None -> stdin) in
     let dice = 
       let (decls,exp) = Parser.dice Lexer.token lb in
       (decls, defs exp) in
@@ -196,7 +197,7 @@ struct
                     arg = "gt" || arg = "lt"
             then (col2 := arg;
                   run0 args filename n defs)
-            else run0 args arg n defs
+            else run0 args (Some arg) n defs
           | Some (name,value) ->
             run0 args filename n
               (fun d -> Syntax.Syntax.LET
@@ -227,7 +228,7 @@ struct
   let spec =
     let open Core.Command.Spec in
     empty
-    +> anon ("filename" %: string)
+    +> anon (maybe ("filename" %: string))
 
   let command =
     Core.Command.basic

--- a/main.ml
+++ b/main.ml
@@ -60,14 +60,14 @@ struct
 
   let printVal v = print (stringIVal v ^"\n")
 
-  let rec gtList a b = match a,b with 
+  let rec gtList l1 l2 = match l1, l2 with
     | [], _ -> false
-    | (a::l1), [] -> true
+    | (_::_), [] -> true
     | (a::l1), (b::l2) -> a>b || a=b && gtList l1 l2
 
   let rec printDist1 a b = 
     match (a, b) with
-    | [], pad -> ()
+    | [], _ -> ()
     | ((a,p)::l), pad ->
       let s1 = stringIVal a in
       let s2 = match a with
@@ -104,7 +104,7 @@ struct
     let myAdd3 a b = match a,b with
         m, ((Interpreter.VAL (n::_),p),s) ->
         p*.(abs_float (float_of_int n -. m))+.s
-      | m, (_,s) -> s in
+      | _, (_,s) -> s in
     let maximum x y = if x > y then x else y in
     let maxLen = List.fold_right maximum
         (List.map (fun x -> match x with
@@ -115,7 +115,7 @@ struct
                  (List.map String.length ts) 0
              | (pair,_) -> String.length (stringIVal pair))
             l) 0 in
-    let pad = implode (tabulate (maxLen+5) (fun x -> ' ')) in
+    let pad = implode (tabulate (maxLen+5) (fun _ -> ' ')) in
     let s1 = "Value" in
     let s2 = String.sub pad 0 (String.length pad - String.length s1) in
     let s3 = if !percent
@@ -132,7 +132,7 @@ struct
       | (false,_)    -> " Probability for >   " in
     let mean = (if List.for_all (fun x ->
         (match x with
-           (Interpreter.VAL x, p) -> List.length x <= 1
+           (Interpreter.VAL x, _) -> List.length x <= 1
          | _ -> false)) l
        then
          let m = List.fold_right (fun x y -> myAdd (x, y)) l 0.0 in
@@ -164,7 +164,7 @@ struct
     let dice = 
       let (decls,exp) = Parser.dice Lexer.token lb in
       (decls, defs exp) in
-    let roll = fun n -> printVal (Interpreter.rollDice dice) in
+    let roll = fun _ -> printVal (Interpreter.rollDice dice) in
     List.hd (tabulate n roll)
 
   let errorMess s = print s (* TODO: To stderr? *)
@@ -182,11 +182,10 @@ struct
       | None -> Random.self_init() in
     try
       run filename count (fun d -> d)
-    with Parsing.YYexit ob -> errorMess "Parser-exit\n"
+    with Parsing.YYexit _ -> errorMess "Parser-exit\n"
        | Parsing.Parse_error ->
-         let (p1,p2) = (0, 0) in
          let (lin,col)
-           = Lexer.getLineCol p2
+           = Lexer.getLineCol 0
              (!Lexer.currentLine)
              (!Lexer.lineStartPos) in
          errorMess ("Parse-error at line "

--- a/main.ml
+++ b/main.ml
@@ -5,8 +5,6 @@ open Parser
 module Main =
 struct
 
-  exception ParamErr of string
-
   let percent = ref true
 
   let pmax = ref 1.0
@@ -200,7 +198,6 @@ struct
          errorMess ("Runtime error: " ^mess^ " at line "
                     ^ string_of_int lin ^ ", column " ^ string_of_int col)
        | Sys_error s -> errorMess ("Exception: " ^ s)
-       | ParamErr s -> errorMess ("Bad command-line parameter: " ^ s)
 
   let spec =
     let open Core.Command.Spec in

--- a/main.ml
+++ b/main.ml
@@ -205,7 +205,11 @@ struct
                    defs d,(0,0))))
       | Some n -> run0 args filename n defs
 
-  let main filename = try
+  let main filename seed =
+    let _ = match seed with
+        Some s -> Random.init s
+      | None -> Random.self_init() in
+    try
       run0 [] filename 1 (fun d -> d)
     with Parsing.YYexit ob -> errorMess "Parser-exit\n"
        | Parsing.Parse_error ->
@@ -229,16 +233,16 @@ struct
     let open Core.Command.Spec in
     empty
     +> anon (maybe ("filename" %: string))
+    +> flag "--seed" (optional int) ~doc:"int Seed value for dice"
 
   let command =
     Core.Command.basic
       ~summary:"Simulate dice rolling based on a domain-specific syntax"
       ~readme:(fun () -> "Command-line options")
       spec
-      (fun filename () -> main filename)
+      (fun filename seed () -> main filename seed)
 
   let _ =
-    Random.self_init();
     Core.Command.run ~version:"0.0.1" command
 end
 


### PR DESCRIPTION
Use Command module from Core. This is the first step to fully adopting Core as a replacement to OCaml standard library in the project.