### PR TITLE
Use Core Base

### DIFF
--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -28,11 +28,6 @@ struct
       [] -> true
     | _ -> false
 
-  let rec zip lst1 lst2 = match lst1,lst2 with
-    | [],_ -> []
-    | _, []-> []
-    | (x::xs),(y::ys) -> (x,y) :: (zip xs ys)
-
   let tabulate n f =  List.init n (fun x -> f(x + 1))
 
   let rand n = 1 + Random.int n
@@ -365,12 +360,7 @@ struct
     match lookup f decs with
       None -> raise (RunError ("Unknown function: "^f,p))
     | Some (Syntax.Func(pars, body, _)) ->
-      let zip a b = match a, b with
-          [], [] -> []
-        | (x::xs), (y::ys) -> (x,y) :: zip xs ys
-        | _, _ -> raise (RunError ("Wrong number of args to "^f,p))
-      in
-      evalExp0 body (zip pars vs) decs
+      evalExp0 body (List.zip_exn pars vs) decs
     | Some (Syntax.Comp(empty, single, union, pos)) ->
       (match vs with
          [VAL v] -> compositional (v, empty, single, union, decs, pos)

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -16,12 +16,6 @@ struct
     | 0 -> 0
     | _ -> (n / abs(n))
 
-  let rec take k xs = match k with
-    | 0 -> []
-    | k -> match xs with
-      | [] -> failwith "take"
-      | y::ys -> y :: (take (k - 1) ys)
-
   let rec drop' n h =
     if Int.equal n 0
     then h
@@ -29,11 +23,6 @@ struct
             (match h with
                _::b -> b
              | [] -> failwith "drop"))
-
-  let rec last = function
-      x::[] -> x
-    | _::xs -> last xs
-    | [] -> failwith "last"
 
   let is_empty = function
       [] -> true
@@ -212,7 +201,7 @@ struct
            (VAL [n], VAL l) ->
            if n<0 then raise (RunError ("Negative arg to least", p))
            else if List.length l <= n then VAL l
-           else VAL (take n l)
+           else VAL (List.take l n)
          | _ -> raise (RunError ("illegal arg to least", p)))
       | Syntax.LARGEST (e1,e2, p) ->
         (match (evalExp e1 table,evalExp e2 table) with
@@ -298,7 +287,7 @@ struct
       | Syntax.REPEAT (x,e1,e2,continue,p) ->
         (match evalExp e1 table with
            VAL v ->
-           VAL (last (iterate v x e1 e2 continue table decs p))
+           VAL (List.last_exn (iterate v x e1 e2 continue table decs p))
          | _ -> raise (RunError ("illegal arg to repeat",p)))
       | Syntax.FOREACH (x,e1,e2,p) ->
         (match evalExp e1 table with

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -1,5 +1,6 @@
 {
 
+open Core
 open Lexing
 open Parser
 let currentLine = ref 1

--- a/src/main.ml
+++ b/src/main.ml
@@ -21,7 +21,7 @@ struct
 
   let tupleSnd x = let _, y = x in y
 
-  let tabulate n f =  List.init n ~f:(fun x -> f(x + 1))
+  let times n f =  List.init n ~f:(fun _ -> f())
 
   let implode l = String.concat ~sep:"" (List.map ~f:(fun x -> String.make 1 x) l)
 
@@ -113,7 +113,7 @@ struct
                    (List.map ~f:String.length ts) ~init:0
                | (pair,_) -> String.length (stringIVal pair))
            l) ~init:0 in
-    let pad = implode (tabulate (maxLen+5) (fun _ -> ' ')) in
+    let pad = implode (times (maxLen+5) (fun _ -> ' ')) in
     let s1 = "Value" in
     let s2 = String.sub pad ~pos:0 ~len:(String.length pad - String.length s1) in
     let s3 = if !percent
@@ -163,7 +163,7 @@ struct
       let (decls,exp) = Parser.dice Lexer.token lb in
       (decls, defs exp) in
     let roll = fun _ -> printVal (Interpreter.rollDice dice) in
-    List.hd (tabulate n roll)
+    List.hd (times n roll)
 
   let errorMess s = print s (* TODO: To stderr? *)
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -26,16 +26,12 @@ struct
   let implode l = String.concat ~sep:"" (List.map ~f:(fun x -> String.make 1 x) l)
 
   let rec stringVal l =
-    concatenate
+    String.concat
+      ~sep:" "
       (List.map
          ~f:(fun n -> if n>=0 then string_of_int n
               else "-" ^ string_of_int (~-n))
          l)
-
-  and concatenate = function
-    | [] -> ""
-    | [x] -> x
-    | (x :: xs) -> x ^ " " ^ concatenate xs
 
   let realtostring n = if n<0.0 then "-" ^ string_of_float (~-.n)
     else string_of_float n

--- a/src/main.ml
+++ b/src/main.ml
@@ -198,20 +198,19 @@ struct
        | Sys_error s -> errorMess ("Exception: " ^ s)
 
   let spec =
-    let open Core.Command.Spec in
+    let open Command.Spec in
     empty
     +> anon (maybe ("filename" %: string))
     +> flag "--times" (optional_with_default 1 int) ~doc:"int Number of rolls"
     +> flag "--seed" (optional int) ~doc:"int Seed value for dice"
 
   let command =
-    Core.Command.basic
+    Command.basic_spec
       ~summary:"Simulate dice rolling based on a domain-specific syntax"
       ~readme:(fun () -> "Command-line options")
       spec
       (fun filename count seed () -> main filename count seed)
 
   let () =
-    Core.Command.run ~version:"0.0.1" command
+    Command.run ~version:"0.0.1" command
 end
-

--- a/src/main.ml
+++ b/src/main.ml
@@ -21,7 +21,7 @@ struct
 
   let tupleSnd x = let _, y = x in y
 
-  let tabulate n f =  List.init n (fun x -> f(x + 1))
+  let tabulate n f =  List.init n ~f:(fun x -> f(x + 1))
 
   let implode l = String.concat ~sep:"" (List.map ~f:(fun x -> String.make 1 x) l)
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -25,15 +25,15 @@ struct
 
   let implode l = String.concat ~sep:"" (List.map ~f:(fun x -> String.make 1 x) l)
 
-  let rec stringVal l =
+  let stringVal l =
     String.concat
       ~sep:" "
       (List.map
-         ~f:(fun n -> if n>=0 then string_of_int n
+         ~f:(fun n -> if n >= 0 then string_of_int n
               else "-" ^ string_of_int (~-n))
          l)
 
-  let realtostring n = if n<0.0 then "-" ^ string_of_float (~-.n)
+  let realtostring n = if n < 0.0 then "-" ^ string_of_float (~-.n)
     else string_of_float n
 
   let padrealtostring p =
@@ -46,7 +46,7 @@ struct
       then " "^realtostring p
       else realtostring p
     in
-    ps ^ String.sub padding 0 (20-String.length ps)
+    ps ^ String.sub padding ~pos:0 ~len:(20-String.length ps)
 
   let rec stringIVal = function
     | Interpreter.VAL l -> stringVal l
@@ -69,7 +69,7 @@ struct
       let s1 = stringIVal a in
       let s2 = match a with
           Interpreter.VAL _ ->
-          String.sub pad 0 (String.length pad - String.length s1)
+          String.sub pad ~pos:0 ~len:(String.length pad - String.length s1)
         | _ -> "" in
       let s2' = match a with
           Interpreter.VAL _ -> ""
@@ -115,7 +115,7 @@ struct
            l) ~init:0 in
     let pad = implode (tabulate (maxLen+5) (fun _ -> ' ')) in
     let s1 = "Value" in
-    let s2 = String.sub pad 0 (String.length pad - String.length s1) in
+    let s2 = String.sub pad ~pos:0 ~len:(String.length pad - String.length s1) in
     let s3 = if !percent
       then "    % =              "
       else "  Probability for =  " in

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -1,5 +1,7 @@
 %{
 
+open Core
+
 module S = Syntax
 
 let p0 = (0,0)
@@ -22,7 +24,7 @@ let makeBinaryFunction (name, constr) =
 
 let predef =
   List.map
-    makeUnaryFunction
+    ~f:makeUnaryFunction
     [("-", (fun (x, y) -> S.Syntax.UMINUS (x, y)));
       ("d", (fun (x, y) -> S.Syntax.D (x, y)));
       ("z", (fun (x, y) -> S.Syntax.Z (x, y)));
@@ -37,7 +39,7 @@ let predef =
       ("different", (fun (x, y) -> S.Syntax.DIFFERENT (x, y))) ]
   @
   List.map
-    makeBinaryFunction
+    ~f:makeBinaryFunction
     [("+", (fun (x, y, z) -> S.Syntax.PLUS (x, y, z)));
       ("*", (fun (x, y, z) -> S.Syntax.TIMES (x, y, z)));
       ("U", (fun (x, y, z) -> S.Syntax.CONC (x, y, z)))]

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -1,3 +1,5 @@
+open Core
+
 module Syntax =
 struct
 
@@ -113,7 +115,7 @@ struct
       "(if " ^ showExp e1 ^ "\nthen " ^ showExp e2 ^ "\nelse " ^ showExp e3 ^ ")"
     | CALL (f, es, _) ->
       "call " ^ f ^ "(" ^
-      String.concat "" (List.map (fun e -> showExp e ^ ",") es) ^ ")"
+      String.concat ~sep:"" (List.map es ~f:(fun e -> showExp e ^ ",")) ^ ")"
     | STRING (s, _) -> "\"" ^ s ^ "\""
     | SAMPLE (e1, _) -> "'( " ^ showExp e1 ^ ")"
     | SAMPLES (e1, e2, _) -> "(" ^ showExp e1 ^ " ' " ^ showExp e2 ^ ")"


### PR DESCRIPTION
Use the Base standard library replacement from Core. Require `open Core` in every file.